### PR TITLE
check if out dir is a link

### DIFF
--- a/pylib/file/file_utils.py
+++ b/pylib/file/file_utils.py
@@ -43,7 +43,7 @@ class FileUtils:
     Args:
       dir: string: The directory to build.
     """
-    if not os.path.exists(dir): os.makedirs(dir)
+    if not os.path.exists(dir) and not os.path.islink(dir): os.makedirs(dir)
 
   @classmethod
   def CopyDirTree(cls, src, dst):


### PR DESCRIPTION
Sometimes the `pipeline/out` directory could be a link instead of an actual directory. In this case we don't want pylib to try and create a dir.