### PR TITLE
allow `zeus` to run from anywhere inferring the correct script from env

### DIFF
--- a/pylib/zeus/pipeline_config.py
+++ b/pylib/zeus/pipeline_config.py
@@ -13,10 +13,10 @@ from pylib.file.file_utils import FileUtils
 import pylib.util.singleton as singleton
 
 Flags.PARSER.add_argument('--id',
-                          type=str, required=True,
+                          type=str, required=False,
                           help='The id of the pipeline. .e.g "hotel", "suggest", etc.')
 Flags.PARSER.add_argument('--root',
-                          type=str, required=True,
+                          type=str, required=False,
                           help='The root directory specifying the top level of the pipeline.')
 Flags.PARSER.add_argument('--publish_root',
                           type=str, default='',


### PR DESCRIPTION
problem: debugging pipelines is tedious because one has to use `zeus_{generate,process,index,validate}` magic which leads to monstrous commands like `./pipeline/zen/generate/zeus_generate run pipeline/zen/generate/run/00*`

this commit allows you to just type `zeus run
pipeline/zen/generate/run/00_*` or if you cd into the tasks directory just `zeus run 00_*`